### PR TITLE
add missing dependency

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -24,6 +24,7 @@ perl = v5.14.0
 Types::Standard = 0
 Hash::AsObject = 0
 Log::Log4perl = 0
+Log::Dispatch = 0
 Moo = 0
 Path::Tiny = 0
 File::ShareDir = 0


### PR DESCRIPTION
I got following error when testing.

```
% perl -Mlib t/00-load.t
not ok 1 - use OS::Package;
#   Failed test 'use OS::Package;'
#   at t/00-load.t line 26.
#     Tried to use 'OS::Package'.
#     Error:  ERROR: can't load appenderclass 'Log::Dispatch::File'
# Can't locate Log/Dispatch/File.pm in @INC (you may need to install the Log::Dispatch::File module) (@INC contains: /home/syohei/.opam/4.01.0/lib/perl5 /home/syohei/.plenv/versions/5.20.1/lib/perl5/site_perl/5.20.1/x86_64-linux-thread-multi /home/syohei/.plenv/versions/5.20.1/lib/perl5/site_perl/5.20.1 /home/syohei/.plenv/versions/5.20.1/lib/perl5/5.20.1/x86_64-linux-thread-multi /home/syohei/.plenv/versions/5.20.1/lib/perl5/5.20.1 .) at (eval 93) line 2.
```
